### PR TITLE
Show db lock errors in the benchmark

### DIFF
--- a/django_sqlite_benchmark/urls.py
+++ b/django_sqlite_benchmark/urls.py
@@ -1,12 +1,13 @@
 from django.contrib import admin
 from django.urls import path
 from counters.views import counter, hello_word
-from write.views import write_row_from_json
+from write.views import write_row_after_read_from_json, write_row_from_json
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     # /counter/<slug>/ runs counter view
     path("counter/<slug>/", counter),
     path("write/", write_row_from_json),
+    path("write_after_read/", write_row_after_read_from_json),
     path("hello/", hello_word),
 ]

--- a/locustfile.py
+++ b/locustfile.py
@@ -23,3 +23,7 @@ class CounterOne(HttpUser):
     @task
     def write(self):
         self.client.post("/write/", next(rows))
+
+    @task
+    def write_after_read(self):
+        self.client.post("/write_after_read/", next(rows))

--- a/write/views.py
+++ b/write/views.py
@@ -1,10 +1,34 @@
-from django.http import JsonResponse, HttpResponse
+from django.db import transaction
 from django.views.decorators.csrf import csrf_exempt
 from .models import Row
 
 
 @csrf_exempt
 def write_row_from_json(request):
+    if request.method == "POST":
+        data = request.POST
+        row = Row(
+            name=data["name"],
+            campaign=data["campaign"],
+            voice=data["voice"],
+            recognize=data["recognize"],
+            inside=data["inside"],
+            growth=data["growth"],
+            side=data["side"],
+            yard=data["yard"],
+            discussion=data["discussion"],
+        )
+        row.save()
+        # Return JSON of row
+        return JsonResponse(row.to_json())
+    else:
+        return HttpResponse("Not allowed", status=405)
+
+
+@csrf_exempt
+@transaction.atomic()
+def write_row_after_read_from_json(request):
+    Row.objects.filter().first()  # Do a read query before the write
     if request.method == "POST":
         data = request.POST
         row = Row(


### PR DESCRIPTION
I've added a new endpoint that shows how to trigger write errors in Django. The recipe is:

1. Start a transaction.
2. Do a read query.
3. Attempt to do a write query.

This is because the read query prevents SQLite from falling back to the busy_handler and immediately raises the database locked error. The solution is to acquire the lock before the read using `BEGIN IMMEDIATE`. (See my [blog post](https://blog.pecar.me/django-sqlite-dblock) about this for more details)

Unfortunately, you can't do this easily in Django. The cleanest option that I know of is to write your own engine that starts all transactions in immediate mode. 

I've already opened [a thread on Django Forum](https://forum.djangoproject.com/t/sqlite-and-database-is-locked-error/26994/3) about this, but I think it's going to be tough to make a change that doesn't break existing apps that are be relying on the fact that all transactions are deferred.

PS: I opened the PR for you to see how to reproduce the issue. I don't expect you to merge it :)